### PR TITLE
[#46] adjusted fragment_url_search layout confirm button width

### DIFF
--- a/app/src/main/res/layout/fragment_url_search.xml
+++ b/app/src/main/res/layout/fragment_url_search.xml
@@ -26,7 +26,7 @@
         android:id="@+id/butConfirm"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="50dp"
-        android:layout_marginRight="50dp"
+        android:layout_marginLeft="18dp"
+        android:layout_marginRight="18dp"
         android:text="@string/confirm_label"/>
 </LinearLayout>


### PR DESCRIPTION
Button width was inconsistent with the design layout for other views of the app displaying similar buttons.