### PR TITLE
[#126][#127][#130][#132] Categories switch view fix

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/CreateCategoryDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/CreateCategoryDialog.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Future;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.feed.Category;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.fragment.SubscriptionFragment;
@@ -76,6 +77,8 @@ public class CreateCategoryDialog {
                                 openMoveDialog = false;
                                 lastSelectedFeedId = -1;
                             }
+
+                            subscriptionFragment.setUserPreferencesToCategoryView();
 
                         } else {
                             if (isDuplicateCategoryName) {

--- a/app/src/main/java/de/danoeh/antennapod/dialog/MoveToCategoryDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/MoveToCategoryDialog.java
@@ -116,6 +116,9 @@ public class MoveToCategoryDialog {
                         fragment.refresh();
                     }
                 }
+
+                fragment.setUserPreferencesToCategoryView();
+
                 dialog.dismiss();
 
             }
@@ -137,6 +140,7 @@ public class MoveToCategoryDialog {
                 createCategoryDialog.setOpenMoveDialogStatus(true);
                 createCategoryDialog.setLastSelectedFeedId(feedId);
                 createCategoryDialog.showCreateCategoryDialog(activity, fragment);
+                fragment.setUserPreferencesToCategoryView();
             }
         });
 

--- a/app/src/main/java/de/danoeh/antennapod/dialog/RemoveFromCategoryDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/RemoveFromCategoryDialog.java
@@ -52,7 +52,9 @@ public class RemoveFromCategoryDialog {
             public void onClick(DialogInterface dialog, int which) {
                 DBWriter.updateFeedCategory(feedId, PodDBAdapter.UNCATEGORIZED_CATEGORY_ID);
                 Toast.makeText(activity, activity.getString(R.string.successfully_removed_from_category), Toast.LENGTH_LONG).show();
-                fragment.refresh();
+
+                fragment.setUserPreferencesToCategoryView();
+
             }
         });
         builder.setNegativeButton(R.string.cancel_label, new DialogInterface.OnClickListener() {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -482,6 +482,14 @@ public class SubscriptionFragment extends Fragment {
         return super.onOptionsItemSelected(item);
     }
 
+    public void setUserPreferencesToCategoryView(){
+        if(!categoryView) {
+            categoryView = !categoryView;
+            UserPreferences.setCategoryToggle(categoryView);
+            refresh();
+        }
+    }
+
     @Override
     public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {
         super.onCreateContextMenu(menu, v, menuInfo);


### PR DESCRIPTION
Story: [#101]
Task: [#126]
Task: [#127]
Task: [#130]
Task: [#132]

If not already on the category view of the subscriptions page, switch to that view when adding a new category, moving a podcast into a category or removing a podcast from a category.