### PR TITLE
Amend version numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,28 @@
 Change Log
 ==========
 
-Version 1.0
+Version 1.7.0.1
 -------------
+[Release1](https://github.com/lucastle6969/AntennaPod390/releases/tag/release1)
 * This version implements changes from [AntennaPod](https://github.com/AntennaPod/AntennaPod/blob/develop/CHANGELOG.md "AntennaPod ChangeLog") version 1.7.0
+* The tagged release displays version number 1.7.0
 * Search Providers have uniform description and layouts [#28](https://github.com/lucastle6969/AntennaPod390/issues/28)
 * Navigation bar has a new ordering [#9](https://github.com/lucastle6969/AntennaPod390/issues/9)
 * Add podcast page has a less cluttered, new interface [#10](https://github.com/lucastle6969/AntennaPod390/issues/10)
 
-Version 2.0
+Version 1.7.0.2
 -------------
+[Release2](https://github.com/lucastle6969/AntennaPod390/releases/tag/release2-hotfix)
 * Single Search Page for all 3 providers, displayed in a tabbed view allowing the user to swipe between provider search fragments. A forth tab allows for URL input podcast subscription. [#13](https://github.com/lucastle6969/AntennaPod390/issues/13)
 * Podcast of the Day provides users with a new daily podcast suggestion, with the ability to generate new suggestions without waiting for a new day.[#36](https://github.com/lucastle6969/AntennaPod390/issues/36)
 * Users can add bookmarks to their podcast episodes.[#37](https://github.com/lucastle6969/AntennaPod390/issues/37)
 * Users can manage the bookmarks on their podcast episodes.[#38](https://github.com/lucastle6969/AntennaPod390/issues/38)
+* The tagged release displays version number 1.7.0
+
+Version 1.7.0.3
+-------------
+* Categories
+* Rewind on play
+* Radio Streaming
+* Podcast Sharing
+* Achievements


### PR DESCRIPTION
The version number in the app has been showing 1.7.0 in our past 2 releases because this is where we branched off from [AntennaPod](https://github.com/AntennaPod/AntennaPod)
The original AntennaPod has moved on to 1.7.1, so we feel it is appropriate to retroactively label our releases as 1.7.0.1, 1.7.0.2 and 1.7.0.3
for continuity with the original app.

in conjunction with #193 